### PR TITLE
Finish TableView::cancelAndStoleTouch

### DIFF
--- a/GD/code/src/TableView.cpp
+++ b/GD/code/src/TableView.cpp
@@ -96,10 +96,10 @@ void TableView::cancelAndStoleTouch(cocos2d::CCTouch *touch, cocos2d::CCEvent *e
     cocos2d::CCSet* set = new cocos2d::CCSet;
     set->addObject(touch);
     set->autorelease();
+    m_cancellingTouches = true;
     cocos2d::CCDirector::sharedDirector()->getKeyboardDispatcher();
-    // Unknown Call....
-    // (**(code **)(*piVar1 + 0x34))(piVar1,this_00,event);
-    // *(undefined *)&this[1].vtable = 0;
+    cocos2d::CCDirector::sharedDirector()->getTouchDispatcher()->touchesCancelled(set, event);
+    m_cancellingTouches = false;
     claimTouch(touch);
 }
 


### PR DESCRIPTION
Not sure whether to make the other change for the if condition in `ccTouchMoved`, but I believe https://github.com/CallocGD/GD-2.205-Decompiled/blob/e4f57342d13d26ea5269ac68e2db640b4b7d9414/GD/code/src/TableView.cpp#L157 should actually be
```cpp
if (fabsf(touchPoint.y - m_touchLastY) >= 10.0F) {
```